### PR TITLE
Deploy database on node with volumes label

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -14,6 +14,10 @@ services:
 
   postgres:
     image: postgres:17.0-alpine
+    deploy:
+      placement:
+        constraints:
+          - node.labels.volumes==true
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
To make sure the data is persisted, the database should always be deployed on the same node. On a production environment, usually the nodes would share a volume, e.g., object storage bucket or a shared disk from a cloud provider.